### PR TITLE
fix: Inertia transformation and swing foot placement

### DIFF
--- a/src/mpc.py
+++ b/src/mpc.py
@@ -158,7 +158,7 @@ def get_simplified_dynamics(mpc, biped, x_ref, foot_ref):
     yaw = x_ref[2]
     pitch = x_ref[1]
     R = eul2rotm(x_ref[0:3])
-    I = R.T @ biped.I @ R
+    I = R @ biped.I @ R.T
 
     # Compute Ac matrix
     R_inv = np.linalg.inv(np.array([
@@ -506,14 +506,15 @@ def getFootPositionWorld(x_fb, q, biped):
 
 def swingLegControl(x_fb, t, pf_w, vf_w, mpc, side):
     global foot_r, foot_l
+    yaw = x_fb[2]
     y_offset = mpc.y_offset
     foot_des_x = (
         x_fb[3] + x_fb[9] * 1 / 2 * mpc.h / 2 * mpc.dt
-        + mpc.kv * (x_fb[3] - mpc.x_cmd[3])
+        + mpc.kv * (x_fb[3] - mpc.x_cmd[3]) - y_offset * side * np.sin(yaw)
     )
     foot_des_y = (
         x_fb[4] + x_fb[10] * 1 / 2 * mpc.h / 2 * mpc.dt
-        + mpc.kv * (x_fb[4] - mpc.x_cmd[4]) + y_offset*side
+        + mpc.kv * (x_fb[4] - mpc.x_cmd[4]) + y_offset * side * np.cos(yaw)
     )
     t = np.remainder(t, mpc.dt * mpc.h / 2)
     foot_des_z = mpc.swingHeight * np.sin(np.pi * t / (mpc.dt * mpc.h / 2))


### PR DESCRIPTION
- In get_simplified_dynamics: 
The rotation matrix `R` obtained from Euler angles `x_ref[0:3]` can transform a vector from body frame representation into the world frame ($^w_bR$). From https://ocw.mit.edu/courses/16-07-dynamics-fall-2009/dd277ec654440f4c2b5b07d6c286c3fd_MIT16_07F09_Lec26.pdf, we have $^wI = ^w_bR \cdot ^bI \cdot ^w_bR^\top$.

- In swingLegControl:
All computation are in the world frame, so body frame y_offset should be converted before adding to foot_des_x and foot_des_y
